### PR TITLE
REFPLTB-1970  :  python3-jinja2-native Fetch Error

### DIFF
--- a/recipes/python3-jinja2-native/python3-jinja2-native_2.11.1.bb
+++ b/recipes/python3-jinja2-native/python3-jinja2-native_2.11.1.bb
@@ -4,6 +4,8 @@ DESCRIPTION = "Jinja2 is a modern and designer friendly templating language for 
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://LICENSE.rst;md5=5dc88300786f1c214c1e9827a5229462"
 PYPI_PACKAGE = "jinja2"
+#Remove the SRC_URI set by pypi.bbclass
+SRC_URI_remove="${PYPI_SRC_URI}"
 SRC_URI="https://files.pythonhosted.org/packages/d8/03/e491f423379ea14bb3a02a5238507f7d446de639b623187bccc111fbecdf/Jinja2-2.11.1.tar.gz"
 SRC_URI[md5sum] = "5d88c7e77aa63fc852a04f65dbfe5594"
 SRC_URI[sha256sum] = "93187ffbc7808079673ef52771baa950426fd664d3aad1d0fa3e95644360e250"


### PR DESCRIPTION
Reason for change: pypi.bbclass is prepending the SRC_URI with PYPI_SRC_URI. python3-jinja2-native.bb is actually overriding the SRC_URI with its own SRC_URI. The override was happening properly with dunfell pypi.bbclass as it had "SRC_URI += "${PYPI_SRC_URI}"". But now this += is changed to prepend and hence the override is not working.So we are removing the PYPI_SRC_URI from SRC_URI to override locally in the bb.
Test Procedure: bitbake python3-jinja2-native should succeed without any fetch failures.
 Risks: Low

Signed-off-by: Ssandhyarani <sirasanagandla.sandhyarani@ltts.com>